### PR TITLE
update attributes naming for text modifier

### DIFF
--- a/spec/text-modifiers.md
+++ b/spec/text-modifiers.md
@@ -25,8 +25,8 @@ interface mixin CanvasTextDrawingStyles {
   // current values (font, textAlign, textBaseline, direction)...
 
   // new values
-  attribute DOMString textLetterSpacing;      // CSS letter-spacing
-  attribute DOMString textWordSpacing;        // CSS word-spacing
+  attribute DOMString letterSpacing;          // CSS letter-spacing
+  attribute DOMString wordSpacing;            // CSS word-spacing
   attribute DOMString fontVariantCaps;        // CSS font-variant-caps
   attribute DOMString fontKerning;            // CSS font-kerning
   attribute DOMString fontStretch;            // CSS font-stretch
@@ -49,7 +49,7 @@ Example usage
 const canvas = document.createElement('canvas');
 const ctx = canvas.getContext('2d');
 
-ctx.textLetterSpacing = "3px";
+ctx.letterSpacing = "3";
 ctx.fontVariantCaps = "all-small-caps";
 
 ```


### PR DESCRIPTION
After the [TAG review](https://github.com/w3ctag/design-reviews/issues/627), we decided to change textLetterSpacing to letterSpacing and textWordSpacing to workSpacing.