### PR TITLE
remove unnecessary parameter in drawMesh overload

### DIFF
--- a/spec/mesh2d.md
+++ b/spec/mesh2d.md
@@ -89,8 +89,7 @@ interface CanvasRenderingContext2D {
     // Triangle mesh using explicit vertex colors.
     [HighEntropy, RaisesException] void drawMesh(Mesh2DVertexBuffer vertex_buffer,
                                                  Mesh2DColorBuffer color_buffer,
-                                                 Mesh2DIndexBuffer index_buffer,
-                                                 MeshTextureSource texture_source);
+                                                 Mesh2DIndexBuffer index_buffer);
 };
 ```
 


### PR DESCRIPTION
As a side-node, I wanted to mention that we think this API is very important:
1. It abstracts from a specific GPU API (WebGL/WebGPU)
2. remove substancial boilerplate code.

We are looking to implement a polyfill of this API using WebGL.