### PR TITLE
Further revision to WebGPU transfer spec.

### DIFF
--- a/spec/webgpu.md
+++ b/spec/webgpu.md
@@ -30,7 +30,17 @@ dictionary Canvas2dGPUTransferOption {
 
 [
     RuntimeEnabled=Canvas2dGPUTransfer,
-    Exposed=(Window,Worker),
+    Exposed=(Window, Worker),
+    SecureContext
+] interface CanvasTransferableGPUTexture : GPUTexture {
+    // This class doesn't directly add any methods or attributes.
+    // This type enforces that only GPUTextures from a Canvas2D are eligible to
+    // be returned to a canvas. They can only be created via `transferToGPUTexture`.
+};
+
+[
+    RuntimeEnabled=Canvas2dGPUTransfer,
+    Exposed=(Window, Worker),
     SecureContext
 ] interface mixin Canvas2dGPUTransfer {
   [RaisesException] CanvasTransferableGPUTexture transferToGPUTexture(Canvas2dGPUTransferOption options);

--- a/spec/webgpu.md
+++ b/spec/webgpu.md
@@ -2,7 +2,7 @@ WebGPU Transfer
 =======
 **Status**: explainer.
 
-This proposal tries to create better interoperability between Canvas 2D and WebGPU, addressing both performance and ergonomics problems. It provides a low level primitive to transfer a canvas' backbuffer to a WebGPU texture (resetting the canvas to an empty state), and a matching primitive to bring back that texture to Canvas2D.
+This proposal tries to create better interoperability between Canvas 2D and WebGPU, addressing both performance and ergonomics problems. It provides a low level primitive to transfer a canvas' backbuffer to a WebGPU texture (resetting the canvas to an empty image), and a matching primitive to bring back that texture to Canvas2D.
 
 There are 2 use cases in mind for this proposal:
 
@@ -15,36 +15,36 @@ Proposal
 --------
 
 ```webidl
-dictionary Canvas2dWebGPUTransferOption {
+dictionary Canvas2dGPUTransferOption {
   // This GPUDevice will be given access to the canvas' texture.
   GPUDevice device;
 
-  // This label will be assigned to the GPUTexture returned by transferToWebGPU.
+  // This label will be assigned to the GPUTexture returned by transferToGPUTexture.
   DOMString? label;
 
   // This controls the GPUTextureUsage flags of the GPUTexture returned by
-  // transferToWebGPU. The default value will return a canvas texture that is
+  // transferToGPUTexture. The default value will return a canvas texture that is
   // usable as a render attachment, and bindable as a 2D texture.
   GPUTextureUsageFlags usage = 0x14;  // TEXTURE_BINDING | RENDER_ATTACHMENT
 };
 
 [
-    RuntimeEnabled=Canvas2dWebGPUTransfer,
+    RuntimeEnabled=Canvas2dGPUTransfer,
     Exposed=(Window,Worker),
     SecureContext
-] interface mixin Canvas2dWebGPUTransfer {
-  [RaisesException] GPUTexture transferToWebGPU(Canvas2dWebGPUTransferOption options);
-  [RaisesException] undefined transferFromWebGPU(GPUTexture tex);
+] interface mixin Canvas2dGPUTransfer {
+  [RaisesException] CanvasTransferableGPUTexture transferToGPUTexture(Canvas2dGPUTransferOption options);
+  [RaisesException] undefined transferFromGPUTexture(CanvasTransferableGPUTexture tex);
   GPUTextureFormat getTextureFormat();
 };
 
-CanvasRenderingContext2D includes Canvas2DWebGPUTransfer;
-OffscreenCanvasRenderingContext2D includes Canvas2DWebGPUTransfer;
+CanvasRenderingContext2D includes Canvas2DGPUTransfer;
+OffscreenCanvasRenderingContext2D includes Canvas2DGPUTransfer;
 ```
 
-`transferToWebGPU()` returns a [GPUTexture](https://gpuweb.github.io/gpuweb/#gputexture) that can be used in a WebGPU pipeline. After the function is called, the Canvas2D image is returned to an empty, newly-initialized state.
+`transferToGPUTexture()` returns a [CanvasTransferableGPUTexture](https://gpuweb.github.io/gpuweb/#gputexture) that can be used in a WebGPU pipeline. After the function is called, the Canvas2D image is returned to an empty, newly-initialized state. The returned texture is subject to [automatic expiry](https://www.w3.org/TR/webgpu/#automatic-expiry-task-source) and may enter a destroyed state if it is not used within the current Javascript task.
 
-`transferFromWebGPU()` moves the GPUTexture back to the canvas, including any changes that were made to it in the interim. The GPUTexture becomes unavailable for use on WebGPU. Any existing image on the Canvas2D is destroyed.
+`transferFromGPUTexture()` moves the `CanvasTransferableGPUTexture` back to the canvas, preserving any changes that were made to it in the interim. The GPU texture enters a destroyed state, and is unavailable for further use on WebGPU. Any existing image on the Canvas2D is replaced with the image from the GPU texture.
 
 Polyfill for the current proposal [here](../webgpu/webgpu-polyfill.js).
 
@@ -66,7 +66,7 @@ const canvas = new OffscreenCanvas(256, 256);
 const ctx = canvas.getContext('2d');
 ctx.fillText("some text", 10, 50);
 
-const canvasTexture = ctx.transferToWebGPU({device: device});
+const canvasTexture = ctx.transferToGPUTexture({device: device});
 
 const pipeline = device.createRenderPipeline(...);
 
@@ -102,7 +102,7 @@ const ctx = canvas.getContext('2d');
 // ... some Canvas2D work.
 ctx.fillRect(0, 0, 1, 1);
 
-const canvasTexture = ctx.transferToWebGPU({device: device});
+const canvasTexture = ctx.transferToGPUTexture({device: device});
 
 const pipeline = device.createRenderPipeline({fragment: {targets: [{
   format: ctx.getTextureFormat(),
@@ -125,7 +125,7 @@ renderPassEncoder.draw(3, 1, 0, 0);
 renderPassEncoder.end();
 device.queue.submit([commandEncoder.finish()]);
 
-ctx.transferFromWebGPU(canvasTexture);
+ctx.transferFromGPUTexture(canvasTexture);
 
 // ... continue Canvas2D work.
 ctx.fillRect(1, 1, 1, 1);


### PR DESCRIPTION
I did some scrolling through existing API and came to the conclusion that "WebGPU" is just a marketing name, but not an API name. The actual WebGPU APIs never contain the word "Web" anywhere. And really, that makes sense; it's redundant to explicitly label something as "Web" in a WebIDL spec.

This revision strips out "Web" from our API names.

`transfer(To|From)GPU` at that point did not seem to be sufficiently descriptive, so they are now `transfer(To|From)GPUTexture`. 

I would also like to pitch `CanvasTransferableGPUTexture` as the name of the GPUTexture subclass. I mulled it over last night and I think it is better than `Canvas2dGPUTexture` and more usefully descriptive than `CanvasBackedGPUTexture`. (The user is less interested in the backing store, and more interested in how the object can be used.) And since users don't need to type it, the length is a non-issue.

I can make these changes relatively quickly to the source if we agree on them in principle.